### PR TITLE
add prefix to logging API

### DIFF
--- a/ELRouter/ELRouter+Logger.swift
+++ b/ELRouter/ELRouter+Logger.swift
@@ -9,36 +9,36 @@ import Foundation
 
 /// Represents the granularity and severity of a log message.
 /// - Note: If your app has different `flag` values, you can override them value by setting your own.
-public struct LogFlag: OptionSet {
+public struct RouterLogFlag: OptionSet {
     public let rawValue: UInt
 
     public init(rawValue: UInt) {
         self.rawValue = rawValue
     }
 
-    public static var fatal   = LogFlag(rawValue: UInt(1 << 0))
-    public static var error   = LogFlag(rawValue: UInt(1 << 1))
-    public static var warning = LogFlag(rawValue: UInt(1 << 2))
-    public static var info    = LogFlag(rawValue: UInt(1 << 3))
-    public static var debug   = LogFlag(rawValue: UInt(1 << 4))
-    public static var verbose = LogFlag(rawValue: UInt(1 << 5))
+    public static var fatal   = RouterLogFlag(rawValue: UInt(1 << 0))
+    public static var error   = RouterLogFlag(rawValue: UInt(1 << 1))
+    public static var warning = RouterLogFlag(rawValue: UInt(1 << 2))
+    public static var info    = RouterLogFlag(rawValue: UInt(1 << 3))
+    public static var debug   = RouterLogFlag(rawValue: UInt(1 << 4))
+    public static var verbose = RouterLogFlag(rawValue: UInt(1 << 5))
 }
 
 /// Protocol for consuming logs of `ELRouter`.
-public protocol Logger {
+public protocol RouterLogger {
 
     /// Called when the framework wants to log a `message` with an associated `flag`.
     ///
     /// - Parameters:
     ///   - flag: The `flag` the `logMessage` was recorded with
     ///   - message: autoclosure returning the message
-    func log(_ flag: LogFlag, _ message: @autoclosure () -> String)
+    func log(_ flag: RouterLogFlag, _ message: @autoclosure () -> String)
 }
 
 /// Set to consume the logs of `ELRouter`
-public var logger: Logger?
+public var logger: RouterLogger?
 
 /// Convenient wrapper for sending messages to `logger`
-internal func log(_ flag: LogFlag, _ message: @autoclosure () -> String) {
+internal func log(_ flag: RouterLogFlag, _ message: @autoclosure () -> String) {
     logger?.log(flag, message)
 }

--- a/ELRouter/Route.swift
+++ b/ELRouter/Route.swift
@@ -45,8 +45,8 @@ public enum RoutingType: UInt {
 @objc
 open class Route: NSObject {
     /// The name of the route, ie: "reviews"
-    open let name: String?
-    open let type: RoutingType
+    public let name: String?
+    public let type: RoutingType
 
     open var userInfo = [String: AnyObject]()
     
@@ -59,7 +59,7 @@ open class Route: NSObject {
     open internal(set) var parentRoute: Route?
 
     /// Action block
-    open let action: RouteActionClosure?
+    public let action: RouteActionClosure?
     
     public init(_ route: RouteEnum, parentRoute: Route! = nil, action: RouteActionClosure! = nil) {
         self.name = route.spec.name


### PR DESCRIPTION
Add prefix to logging API to avoid collisions with other types.